### PR TITLE
feat: add macOS Intel wheel build and update README platforms

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,6 +95,9 @@ jobs:
           - os: macos-14
             arch: "arm64"
 
+          - os: macos-15-intel
+            arch: "x86_64"
+
         exclude:
           - os: ubuntu-latest
             arch: "auto"

--- a/.github/workflows/update-dcmqi.yml
+++ b/.github/workflows/update-dcmqi.yml
@@ -140,13 +140,16 @@ jobs:
             echo 'set(dcmqi_archive_url "https://github.com/QIICR/dcmqi/releases/download/v${version}/${dcmqi_archive_filename}")'
           } > dcmqiUrls.cmake
 
+          # Update README.md to reference the new dcmqi release version
+          sed -i "s|dcmqi v${current_version}](https://github.com/QIICR/dcmqi/releases/tag/v${current_version})|dcmqi v${latest_version}](https://github.com/QIICR/dcmqi/releases/tag/v${latest_version})|" README.md
+
           # Configure git and create branch
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           branch="dcmqi-v${latest_version}"
           git checkout -b "$branch"
-          git add dcmqiUrls.cmake
+          git add dcmqiUrls.cmake README.md
           git commit -m "feat: update dcmqi from version v$current_version to v$latest_version"
           git push origin "$branch"
 

--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ configuration defined in the `pyproject.toml` file.
 
 ## Packaged dcmqi version
 
-This package wraps the official [dcmqi v1.5.3](https://github.com/QIICR/dcmqi/releases/tag/v1.5.3) release.
+This package wraps the official
+[dcmqi v1.5.3](https://github.com/QIICR/dcmqi/releases/tag/v1.5.3) release.
 
 ## Platforms
 
 The following platforms are supported by the binary wheels:
 
-| OS           | Arch             |
-| ------------ | ---------------- |
-| Linux Intel  | manylinux 64-bit |
-| macOS 13+    | Apple Silicon    |
-| macOS 15+    | Intel            |
-| Windows      | 64-bit           |
+| OS          | Arch             |
+| ----------- | ---------------- |
+| Linux Intel | manylinux 64-bit |
+| macOS 13+   | Apple Silicon    |
+| macOS 15+   | Intel            |
+| Windows     | 64-bit           |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ placed in the PATH for each of the above mentioned libraries. This launcher is
 created during installation by pip, leveraging the `[project.scripts]`
 configuration defined in the `pyproject.toml` file.
 
+## Packaged dcmqi version
+
+This package wraps the official [dcmqi v1.5.3](https://github.com/QIICR/dcmqi/releases/tag/v1.5.3) release.
+
 ## Platforms
 
 The following platforms are supported by the binary wheels:
@@ -36,8 +40,9 @@ The following platforms are supported by the binary wheels:
 | OS           | Arch             |
 | ------------ | ---------------- |
 | Linux Intel  | manylinux 64-bit |
-| macOS 10.10+ | Intel            |
-| macOS 11+    | Apple Silicon    |
+| macOS 13+    | Apple Silicon    |
+| macOS 15+    | Intel            |
+| Windows      | 64-bit           |
 
 ## License
 


### PR DESCRIPTION
- Add macos-15-intel x86_64 to cd.yml build matrix
- Update update-dcmqi workflow to also update README version link
- Fix README platforms table: correct macOS versions, add Windows, add Intel
- Add packaged dcmqi version section to README